### PR TITLE
Fixed languages rendering unordered on lang dropdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ python-dateutil==2.6.1
 python-env==1.0.0
 python-http-client==3.0.0
 pytz==2017.3
+pyuca==1.2
 requests==2.18.4
 scandir==1.6
 sendgrid==5.3.0

--- a/util/misc.py
+++ b/util/misc.py
@@ -1,0 +1,20 @@
+from pyuca import Collator
+
+from flask_babel import Locale
+
+from config import constants
+
+
+def sort_language_constants():
+    """
+    function to generate correct ordering of constants.LANGUAGES list
+    sorted by Unicode characters
+    """
+    c = Collator()
+    lang_names = [Locale(lang).get_language_name(lang).capitalize()
+                  for lang in constants.LANGUAGES]
+    available_languages = dict(zip(lang_names, constants.LANGUAGES))
+    sorted_lang_names = sorted(lang_names, key=c.sort_key)
+
+    return [available_languages[lang_name] for lang_name in sorted_lang_names]
+

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -1,11 +1,15 @@
-from flask import jsonify, redirect, render_template, request, flash, session, g, url_for
+from collections import OrderedDict
+from datetime import datetime
+
+from flask import (jsonify, redirect, render_template,
+                   request, flash, g, url_for)
+from flask_babel import gettext, Babel, Locale
+from flask_recaptcha import ReCaptcha
 
 from app import app
 from config import constants
 from logic.emails import mailing_list
-from datetime import datetime
-from flask_babel import gettext, Babel, Locale
-from flask_recaptcha import ReCaptcha
+from util.misc import sort_language_constants
 
 # Translation: change path of messages.mo files
 app.config['BABEL_TRANSLATION_DIRECTORIES'] = '../translations'
@@ -144,6 +148,7 @@ def get_locale():
 def inject_now():
     return {'now': datetime.utcnow()}
 
+
 @app.context_processor
 def inject_conf_var():
     current_language = get_locale()
@@ -152,9 +157,12 @@ def inject_conf_var():
     except:
         current_language_direction = 'ltr'
     try:
-        available_languages = dict((l,Locale(l).get_language_name(l).capitalize()) for l in constants.LANGUAGES)
+        available_languages =\
+            OrderedDict([(lang,
+                          Locale(lang).get_language_name(lang).capitalize())
+                         for lang in sort_language_constants()])
     except:
-        available_languages = {'en':"English"}
+        available_languages = {'en': "English"}
     return dict(
         CURRENT_LANGUAGE=current_language,
         CURRENT_LANGUAGE_DIRECTION=current_language_direction,


### PR DESCRIPTION
Fixes issue #10 and uses ordering by Unicode chars as suggested by @wanderingstan 

I did try out a few ways to order it by standard locale lib, but found this:https://github.com/jtauber/pyuca
to be working better.

Let me know if you have any changes/concerns in mind.
