### PR TITLE
Add pseudo-class for hoverable links

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -80,8 +80,12 @@ a:hover {
   background-color: #455d75;
 }
 
-.navbar-dark .nav-item>a {
-  color: #ffffff !important;
+.navbar-dark .nav-item > a {
+  color: #c2cbd3;
+}
+
+.navbar-dark .nav-item > a:hover {
+  color: #ffffff;
 }
 
 .navbar-light {
@@ -263,6 +267,10 @@ footer .footer-link {
 
 footer .footer-link a {
   color: #ffffff;
+}
+
+footer .footer-link a:hover {
+  color: #c2cbd3;
 }
 
 footer .logo-container {


### PR DESCRIPTION
This adds hover state indication on the nav and footer links as directed by Aure via #design in Slack. It will look best if the darker hero section is deployed with the background pattern.