### PR TITLE
Small updates to Spanish translation

### DIFF
--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -109,7 +109,7 @@ msgstr "¡Haga nuevos amigos!"
 
 #: templates/flashes.html:7
 msgid "Join Our Telegram"
-msgstr "Únase a nuestro Telegrama"
+msgstr "Únase a nuestro Telegram"
 
 #: templates/flashes.html:10
 msgid "Stay in touch?"
@@ -241,7 +241,7 @@ msgstr "Lea el resumen del producto"
 #: templates/index.html:96
 #, fuzzy
 msgid "Companies building on the Origin Protocol"
-msgstr "Compañías construyendo en Origin"
+msgstr "Empresas construyendo en Origin"
 
 #: templates/index.html:140
 msgid "Build your business on Origin"


### PR DESCRIPTION
Updated two translations:  'Telegrama' should be 'Telegram', as it is a proper noun, and 'Compañías' works for listing companies but 'Empresas' is slightly better.