### PR TITLE
issue/76 bottom background panes fail to render correctly in safari

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -144,8 +144,15 @@ main.landing-page {
   height: 100%;
 }
 
-.partners-section .background-panes {
-  height: 100%;
+.background-panes.bottom-panes {
+  bottom: 0;
+  display: flex;
+  flex: 1;
+  left: 0;
+}
+
+.background-panes.bottom-panes > .align-items-end {
+  flex: 1;
 }
 
 .partners-section .bottom-panes .row-pane {


### PR DESCRIPTION
This resolves #76. More of the CSS should probably be converted to flexbox and the `style.css` could certainly use some cleanup/refactoring. I will hold off on that for now.