### PR TITLE
fix: fix the bottom-half of whitepaper button cannot be clicked

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -248,7 +248,7 @@ main.landing-page {
 
 
 .btn-container {
-  margin: 40px auto;
+  margin: 60px auto;
 }
 
 .btn:hover {


### PR DESCRIPTION
## Done
fix the whitepaper button cannot be clicked. Look at the GIF for more details. As you can see the bottom half of button cannot be clicked.

## Changed
1. change the pixels of `btn-container` from **40px** to **60px**
![grizzledhairybarasingha-max-14mb](https://user-images.githubusercontent.com/12542369/35969258-3f88fc2a-0d01-11e8-93bb-3d5e76688945.gif)
