### PR TITLE
Use Nginx on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: newrelic-admin run-program gunicorn main:app
+web: bin/start-nginx newrelic-admin run-program gunicorn -c nginx/gunicorn.conf main:app
 init: python tools/manage.py db init
 migrate: python tools/manage.py db migrate
 upgrade: python tools/manage.py db upgrade

--- a/README.md
+++ b/README.md
@@ -61,3 +61,23 @@ To enable recaptcha, add the following environment variables to `.env`
 
 You can get Recaptcha keys here: https://www.google.com/recaptcha/admin
 
+## Dev Deployment on Heroku
+
+To deploy a dev copy of the site on Heroku, you'll follow the normal steps you would to deploy on Heroku, with two additional steps.
+
+After the normal setup and linking, you'll need to ensure the site uses both the python and the nginx backend:
+
+	heroku buildpacks:set heroku/python
+	heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nginx
+
+As a minium, you must set these three Heroku config variables:
+
+|Config          |Value|
+|----------------|------|
+|FLASK_SECRET_KEY|(make something up)|
+|PROJECTPATH     |/app|
+|HOST            |(domain name of your dev heroku app)|
+
+There are more optional config variables you can set. See [sample.env](sample.env) for a full list.
+
+

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,57 @@
+# The Heroku Nginx buildpack is hardcoded to look for an Nginx config 
+# file in config/nginx.conf.erb. This file cannot be moved.
+
+
+# Heroku requires the server to run in the foreground
+daemon off;
+
+#Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+
+events {
+	use epoll;
+	accept_mutex on;
+	worker_connections 1024;
+}
+
+http {
+	gzip on;
+	gzip_comp_level 2;
+	gzip_min_length 512;
+
+	server_tokens off;
+
+	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+	access_log logs/nginx/access.log l2met;
+	error_log logs/nginx/error.log;
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	#Must read the body in 5 seconds.
+	client_body_timeout 5;
+
+	upstream app_server {
+		server unix:/tmp/nginx.socket fail_timeout=0;
+	}
+
+	server {
+		listen <%= ENV["PORT"] %>;
+		server_name _;
+		keepalive_timeout 5;
+
+		location /static/ {
+				alias /app/static/;
+				expires 20m;
+				add_header Cache-Control public;
+		}
+
+		location / {
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header Host $http_host;
+			proxy_redirect off;
+			proxy_pass http://app_server;
+		}
+	}
+}

--- a/nginx/gunicorn.conf
+++ b/nginx/gunicorn.conf
@@ -1,0 +1,5 @@
+def when_ready(server):
+    # touch app-initialized when ready
+    open('/tmp/app-initialized', 'w').close()
+
+bind = 'unix:///tmp/nginx.socket'


### PR DESCRIPTION
By fronting our Flask app with Nginx:

- Static files don't have to run through our python code
- Large files can be streamed without using up our flask processes
- In the future we could cache pages
- We can easily set sitewide expires headers

This commit gives us about a 33%-50% speed up on the site.

To use this, you need to run one Heroku command:

    heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nginx

