### PR TITLE
Enable Nginx caching on pages for massive speed up

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -67,7 +67,7 @@ http {
 			proxy_pass http://app_server;
 			
 			# Only cache pages that have a language code already set
-			location ~ ^/[a-z][a-z](/.*)?$ {
+			location ~ ^/([a-z][a-z]|zh_Hans|zh_Hant)(/.*)?$ {
 				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 				proxy_set_header Host $http_host;
 				proxy_redirect off;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,6 +35,9 @@ http {
 	upstream app_server {
 		server unix:/tmp/nginx.socket fail_timeout=0;
 	}
+	
+	proxy_cache_path /tmp/cache levels=1:2 keys_zone=my_cache:10m max_size=200m
+	                 inactive=120m use_temp_path=off;
 
 	server {
 		listen <%= ENV["PORT"] %>;
@@ -45,6 +48,16 @@ http {
 				alias /app/static/;
 				expires 20m;
 				add_header Cache-Control public;
+				
+				gzip on;
+				gzip_disable "msie6";
+				gzip_vary on;
+				gzip_proxied any;
+				gzip_comp_level 6;
+				gzip_buffers 16 8k;
+				gzip_http_version 1.1;
+				gzip_min_length 256;
+				gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 		}
 
 		location / {
@@ -52,6 +65,20 @@ http {
 			proxy_set_header Host $http_host;
 			proxy_redirect off;
 			proxy_pass http://app_server;
+			
+			# Only cache pages that have a language code already set
+			location ~ ^/[a-z][a-z](/.*)?$ {
+				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+				proxy_set_header Host $http_host;
+				proxy_redirect off;
+				proxy_pass http://app_server;
+				
+				proxy_cache my_cache;
+				proxy_cache_valid 200 120m;
+				# No caching if the user has session data (for example  an upcoming flash message)
+				proxy_cache_bypass $cookie_SESSION; 
+				add_header X-Proxy-Cache $upstream_cache_status;
+			}
 		}
 	}
 }

--- a/templates/flashes.html
+++ b/templates/flashes.html
@@ -2,17 +2,7 @@
   {% if messages %}
     <script type='text/javascript'>
     {% for message in messages %}
-      {% if message == "telegram" %}
-        setTimeout(function() {
-          alertify.log("{{ gettext("Make new friends!") }}<div class='telegram-btn-container'><a href='{{ universal.TELEGRAM_URL }}' target='_blank'><button class='telegram-btn btn btn-outline-primary btn-min-size'><i class='fab fa-telegram-plane'></i>{{ gettext("Join Our Telegram") }}</button></a></div>", "default", 0)
-        }, 2000);
-      {% elif message == "discord" %}
-        setTimeout(function() {
-          alertify.log("{{ gettext("Want to contribute?") }}<div class='discord-btn-container'><a href='{{ universal.DISCORD_URL }}' target='_blank'><button class='discord-btn btn btn-outline-primary btn-min-size'><i class='fab fa-discord'></i>{{ gettext("Join Our Discord") }}</button></a></div>", "default", 0)
-        }, 2000);
-      {% else %}
         alertify.log("{{ message }}", "default")
-      {% endif %}
     {% endfor %}
     {% if CURRENT_LANGUAGE != "en" %}
       alertify.log("Help improve this translation.<div class='discord-btn-container'><a href='{{ universal.DISCORD_URL }}' target='_blank'><button class='discord-btn btn btn-outline-primary btn-min-size'><i class='fab fa-discord'></i>Join #translation on Discord</button></a></div>", "default", 0)

--- a/templates/index.html
+++ b/templates/index.html
@@ -586,6 +586,11 @@
 
 {% block extra_scripts %}
   <script>
+      setTimeout(function() {
+        alertify.log("{{ gettext("Make new friends!") }}<div class='telegram-btn-container'><a href='{{ universal.TELEGRAM_URL }}' target='_blank'><button class='telegram-btn btn btn-outline-primary btn-min-size'><i class='fab fa-telegram-plane'></i>{{ gettext("Join Our Telegram") }}</button></a></div>", "default", 0)
+      }, 2000);
+  </script>
+  <script>
     var cards = document.querySelectorAll('.partner-card');
     var interval;
 

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -47,7 +47,6 @@ def robots():
 
 @app.route('/<lang_code>')
 def index():
-    flash('telegram')
     return render_template('index.html')
 
 @app.route('/<lang_code>/team')


### PR DESCRIPTION
Time to start receiving home page goes from about 800ms to about 40ms.
I'd guess about a 500ms improvement to overall page load times.

By enabling nginx caching here, a normal visit to the site only touches flask
once for the language redirect from then on, flask isn't even called.

In order for a page to be cached, we check that these conditions are true:
- Must be a GET request with a 200 response
- Must have a language code prefix (two characters - I know there are non-two character language codes, but those aren't quite as popular)
- Must not have a session cookie.

When a user fills in a form on the site, they get a session cookie.
Their next page load uses this cookie, bypasses the cache, and they
get the next page with whatever message should be shown to them.

I've moved the home page Telegram display out from using flash code
so that it does not set a session cookie. The discord flash HTML was
not being used, and has been removed.

This commit also enables gzip for our static content.