### PR TITLE
Collapse some logos and link a floating button to partners form

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -47,6 +47,16 @@ label {
   cursor: pointer;
 }
 
+.tooltip {
+  font-size: 0.8rem;
+  font-weight: 300;
+  font-family: 'Lato', 'Helvetica Neue', 'Arial', sans-serif;
+}
+
+.tooltip .tooltip-inner {
+  padding: 1.2rem;
+}
+
 .form-control {
   background-color: #ebf0f3;
   color: #98a7b4;
@@ -1255,15 +1265,44 @@ footer .company-mission {
   text-align: center;
 }
 
+.building-partners-section .logos.collapsing {
+  margin-bottom: calc(50px + 1.5rem);
+}
+
+.building-partners-section .logos.collapsing,
+.building-partners-section .logos.collapse.show {
+  display: flex;
+  padding-top: 0px;
+}
+
 .building-partners-section .logos .col-12 {
   align-items: center;
   display: flex;
-  padding-bottom: 50px;
+  padding-bottom: 100px;
 }
 
 .building-partners-section .logos .img-graphic img {
   max-height: 60px;
   max-width: 100%;
+}
+
+.building-partners-section .btn-container {
+  margin: auto;
+  text-align: center;
+}
+
+.building-partners-section .btn-container [data-toggle="collapse"] {
+  font-size: 1.125rem;
+  margin-bottom: 100px;
+  padding: 0.4rem 2.2rem;
+}
+
+.building-partners-section .btn-container [data-toggle="collapse"] .amount:before {
+  content: 'More';
+}
+
+.building-partners-section .btn-container [data-toggle="collapse"][aria-expanded="true"] .amount:before {
+  content: 'Less';
 }
 
 .building-partners-section > div > .row {
@@ -1769,13 +1808,6 @@ footer .company-mission {
     left: 39%;
     top: 36%;
     width: 8%;
-  }
-
-  /* this should be replaced with a proper LESS/SASS override, i.e., @grid-columns: 10; */
-  .building-partners-section .logos .col-md-2 {
-    -ms-flex: 0 0 20%;
-    flex: 0 0 20%;
-    max-width: 20%
   }
   .building-partners-section .logos .img-graphic img {
     max-width: 90%;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -41,6 +41,7 @@ $(function() {
   });
 });
 
+// mobile navbar
 $(function(){
   // toggle button icons
   $('.navbar-toggler').on('click', function() {
@@ -79,5 +80,5 @@ $(function(){
 });
 
 $(function () {
-  $('[data-toggle="tooltip"]').tooltip()
+  $('[data-toggle="tooltip"]').tooltip();
 })

--- a/templates/flashes.html
+++ b/templates/flashes.html
@@ -2,11 +2,11 @@
   {% if messages %}
     <script type='text/javascript'>
     {% for message in messages %}
-        alertify.log("{{ message }}", "default")
+        alertify.log("{{ message }}", "default");
     {% endfor %}
     {% if CURRENT_LANGUAGE != "en" %}
-      alertify.log("Help improve this translation.<div class='discord-btn-container'><a href='{{ universal.DISCORD_URL }}' target='_blank'><button class='discord-btn btn btn-outline-primary btn-min-size'><i class='fab fa-discord'></i>Join #translation on Discord</button></a></div>", "default", 0)
+      alertify.log("Help improve this translation.<div class='discord-btn-container'><a href='{{ universal.DISCORD_URL }}' target='_blank'><button class='discord-btn btn btn-primary btn-min-size'><i class='fab fa-discord'></i>Join #translation on Discord</button></a></div>", "default", 0);
     {% endif %}
-</script>
+    </script>
   {% endif %}
 {% endwith %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
       <div class="row">
         <div class="col-12 col-md-6">
           <h1>
-            {% trans %}The sharing economy without intermediaries{% endtrans %}
+            {{ gettext("The sharing economy without intermediaries") }}
           </h1>
           <p>
             {{ gettext("Origin is a protocol for creating sharing economy marketplaces using the Ethereum blockchain and IPFS") }}
@@ -252,7 +252,7 @@
             </div>
             <div class="col-12 col-md-5">
               <h2>
-                Features
+                {{ gettext("Features") }}
               </h2>
               <div class="row">
                 <div class="col-6">
@@ -586,9 +586,9 @@
 
 {% block extra_scripts %}
   <script>
-      setTimeout(function() {
-        alertify.log("{{ gettext("Make new friends!") }}<div class='telegram-btn-container'><a href='{{ universal.TELEGRAM_URL }}' target='_blank'><button class='telegram-btn btn btn-outline-primary btn-min-size'><i class='fab fa-telegram-plane'></i>{{ gettext("Join Our Telegram") }}</button></a></div>", "default", 0)
-      }, 2000);
+    setTimeout(function() {
+      alertify.log("{{ gettext("Make new friends!") }}<div class='telegram-btn-container'><a href='{{ universal.TELEGRAM_URL }}' target='_blank'><button class='telegram-btn btn btn-primary btn-min-size'><i class='fab fa-telegram-plane'></i>{{ gettext("Join Our Telegram") }}</button></a></div>", "default", 0)
+    }, 2000);
   </script>
   <script>
     var cards = document.querySelectorAll('.partner-card');

--- a/templates/partners.html
+++ b/templates/partners.html
@@ -45,16 +45,41 @@
           <div class="row">
             <div class="col-12">
               <div class="logos row justify-content-center">
-                {% for partner in partners_dict %}
-                    <div class="col-12 col-sm-6 {% if loop.index is lessthan 6 %}col-md-2{% else %}col-md-1{% endif %}">
-                      <div class="img-graphic">
-                        <a href="{{ partner.url }}" target="_blank">
-                          <img src="/static/img/partners/{{ partner.name }}.png""
-                            class="{{'%s-logo wow fadeInUp' %partner.name }}" title="{{ partner.desc }}" data-toggle="tooltip">
-                        </a>
-                      </div>
+                {% for partner in partners_dict[0:12] %}
+                  <div class="col-12 col-sm-6 col-md-2">
+                    <div class="img-graphic">
+                      <a href="{{ partner.url }}" target="_blank">
+                        <img src="/static/img/partners/{{ partner.name }}.png""
+                          class="{{'%s-logo wow fadeInUp' %partner.name }}" title="{{ partner.desc }}" data-toggle="tooltip">
+                      </a>
                     </div>
+                  </div>
                 {% endfor %}
+              </div>
+            </div>
+            <div class="col-12">
+              <div class="collapse additional logos row justify-content-center" id="additionalLogos">
+                {% for partner in partners_dict[12:] %}
+                  <div class="col-12 col-sm-6 col-md-2">
+                    <div class="img-graphic">
+                      <a href="{{ partner.url }}" target="_blank">
+                        <img src="/static/img/partners/{{ partner.name }}.png""
+                          class="{{'%s-logo' %partner.name }}" title="{{ partner.desc }}" data-toggle="tooltip">
+                      </a>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+              <div class="btn-container">
+                <button
+                  class="btn btn-outline-primary toggle"
+                  type="button"
+                  data-toggle="collapse"
+                  data-target="#additionalLogos"
+                  aria-expanded="false"
+                  aria-controls="additionalLogos">
+                  View <span class="amount"></span>
+                </button>
               </div>
             </div>
           </div>
@@ -78,10 +103,10 @@
     <div class="container-fluid">
       <div class="row">
         <div class="container foreground-content">
+          <a name="join_our_mission"></a>
           <div class="row">
             <div class="col-12 col-lg-6">
               <div class="build-on-origin-form">
-                <a name="join_our_mission"></a>
                 <h2>
                   {{ gettext("Join our mission!") }}
                 </h2>
@@ -142,4 +167,7 @@
 {% endblock %}
 
 {% block extra_scripts %}
+    <script type='text/javascript'>
+      alertify.log("<a href='#join_our_mission'><button class='btn btn-primary btn-min-size'>Join Our Mission</button></a>", "default", 0);
+    </script>
 {% endblock %}

--- a/templates/presale.html
+++ b/templates/presale.html
@@ -410,7 +410,7 @@
               </div>
 
               <div class="btn-container">
-                <input type="submit" class="btn btn-primary btn-min-size" value="{{ gettext("Submit") }}">
+                <input type="submit" class="btn btn-primary btn-min-size" value="{{ gettext('Submit') }}">
               </div>
             </form>
           </div>


### PR DESCRIPTION
As directed by Aure and Josh in Discord:

<img width="1280" alt="screen shot 2018-03-07 at 10 42 31 pm" src="https://user-images.githubusercontent.com/273937/37133419-e5319526-2258-11e8-800c-3095f48cfbf1.png">

This PR assumes that there will always be more than 12 logos rendered from `config/partner_details.py`.

✅ Chrome
✅ Firefox
✅ Safari
✅ Opera
✅ עברית

This is related to #110, which was primarily addressed in 5886425a98d33d745938a94c90a594cb8d67a096.