### PR TITLE
Issue/168 Presale Alertify popup doesn't work in latest Firefox

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -43,6 +43,11 @@ p {
   margin: 20px auto;
 }
 
+a:not([href]):not([tabindex]) {
+  color: #007bff;
+  cursor: pointer;
+}
+
 label {
   cursor: pointer;
 }

--- a/templates/presale.html
+++ b/templates/presale.html
@@ -75,8 +75,7 @@
                   <input name="email" id="email" type="email" class="form-control" placeholder="{{ gettext("Email") }}" />
                 </div>
                 <div class="form-group">
-                  <p><strong>{{ gettext("Are you an accredited investor?") }}</strong>&nbsp;(<a id="huh" href="javascript:alertify.log(document.getElementById('accredited_popup').innerText)">{{ gettext("Huh?") }}</a>)</p>
-                  <div style="display:none" id="accredited_popup">{{ gettext("An accredited investor must have a net worth of at least $1,000,000, excluding the value of one's primary residence, or have income at least $200,000 each year for the last two years (or $300,000 combined income if married.)") }}</div>
+                  <p><strong>{{ gettext("Are you an accredited investor?") }}</strong>&nbsp;(<a id="huh" data-toggle="tooltip" title="{{ gettext("An accredited investor must have a net worth of at least $1,000,000, excluding the value of one's primary residence, or have income at least $200,000 each year for the last two years (or $300,000 combined income if married.)") }}">{{ gettext("Huh?") }}</a>)</p>
                   <div class="form-check form-check-inline">
                     <label class="form-check-label">
                       <input class="form-check-input" type="radio" name="accredited" id="accredited_yes" value="1" checked="checked" /> <strong>{{ gettext("Yes") }}</strong>


### PR DESCRIPTION
This addresses #168. Firefox treats `href="javascript:` differently than Chrome depending on the return value. But this message that we are showing is too long for the Alertify UX anyway. It should be a tooltip, as this PR proposes.

_* I was unable to test this with the current state of the `master` branch due to some environment issues. But I was able to silo just these changes with one of last week's commits and it works as expected._