### PR TITLE
Break out advisers and extended team

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1229,16 +1229,28 @@ footer .company-mission {
   background-color: #ffffff;
 }
 
-.contributing-team-section .foreground-content {
-  margin-bottom: 131px;
-}
-
 .contributing-team-section h2 {
   margin: 80px auto 40px auto;
 }
 
-.contributing-team-section .left-lower-pane,
-.contributing-team-section .right-lower-pane {
+.advisor-team-section > div > .row {
+  position: relative;
+}
+
+.advisor-team-section {
+  background-color: #ffffff;
+}
+
+.advisor-team-section .foreground-content {
+  margin-bottom: 131px;
+}
+
+.advisor-team-section h2 {
+  margin: 80px auto 40px auto;
+}
+
+.advisor-team-section .left-lower-pane,
+.advisor-team-section .right-lower-pane {
   background-color: #f7f9fb;
 }
 
@@ -1792,7 +1804,7 @@ footer .company-mission {
   .core-team-section h2 {
     margin-top: 120px;
   }
-  .contributing-team-section .foreground-content {
+  .advisor-team-section .foreground-content {
     margin-bottom: 300px;
   }
   .filler-section {
@@ -1900,7 +1912,7 @@ footer .company-mission {
   .core-team-section h2 {
     margin-top: 200px;
   }
-  .contributing-team-section .foreground-content {
+  .advisor-team-section .foreground-content {
     margin-bottom: 360px;
   }
   .social-links {

--- a/templates/team.html
+++ b/templates/team.html
@@ -175,7 +175,7 @@
           <div class="row">
             <div class="col-12">
               <h2>
-                {{ gettext("Contributing Team and Advisors") }}
+                {{ gettext("Extended Team") }}
               </h2>
               <div class="row">
                 <div class="col-12 col-md-6 col-xl-3">
@@ -226,74 +226,6 @@
                     </div>
                     <div class="bio">
                       {{ gettext("Daniel is a full stack, polyglot developer. He's worked on projects from assembly programming to architecting systems tracking billions of dollars of NGO spend worldwide.") }}
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6 col-xl-3">
-                  <div class="team-member">
-                    <div class="headshot-wrapper">
-                      <img src="/static/img/headshot-addison.jpg" class="headshot" alt="Addison Huegel headshot">
-                    </div>
-                    <div class="name">
-                      <a href="https://www.linkedin.com/in/addisonhuegel/" target="_blank">{{ gettext("Addison Huegel") }}
-                      </a>
-                    </div>
-                    <div class="title">
-                      {{ gettext("Advisor/PR") }}
-                    </div>
-                    <div class="bio">
-                      {{ gettext("Addison is a communications and marketing specialist with a degree in Physics from UC Berkeley. He previously worked with the Ethereum Foundation and DEVCON1.") }}
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6 col-xl-3">
-                  <div class="team-member">
-                    <div class="headshot-wrapper">
-                      <img src="/static/img/headshot-melody.jpg" class="headshot" alt="Melody He headshot">
-                    </div>
-                    <div class="name">
-                      <a href="https://www.linkedin.com/in/melody-he-497a5b25/" target="_blank">{{ gettext("Melody He") }}
-                      </a>
-                    </div>
-                    <div class="title">
-                      {{ gettext("Advisor/International BD") }}
-                    </div>
-                    <div class="bio">
-                      {{ gettext("Melody is founder of Spartan Group, a blockchain advisory and investment fund. She was an early investor in TenX and strategic advisor to Gifto and Appcoins.") }}
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6 col-xl-3">
-                  <div class="team-member">
-                    <div class="headshot-wrapper">
-                      <img src="/static/img/headshot-paul.jpg" class="headshot" alt="Paul Veradittakit headshot">
-                    </div>
-                    <div class="name">
-                      <a href="https://www.linkedin.com/in/veradittakit/" target="_blank">{{ gettext("Paul Veradittakit") }}
-                      </a>
-                    </div>
-                    <div class="title">
-                      {{ gettext("Advisor") }}
-                    </div>
-                    <div class="bio">
-                      {{ gettext("Paul is a Partner at Pantera Capital. He is also an advisor to several highly successful cryptocurrency projects including Orchid Labs, Enigma and ICON.") }}
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6 col-xl-3">
-                  <div class="team-member">
-                    <div class="headshot-wrapper">
-                      <img src="/static/img/headshot-joey.jpg" class="headshot" alt="Joey Krug headshot">
-                    </div>
-                    <div class="name">
-                      <a href="https://www.linkedin.com/in/joeykrug/" target="_blank">{{ gettext("Joey Krug") }}
-                      </a>
-                    </div>
-                    <div class="title">
-                      {{ gettext("Advisor") }}
-                    </div>
-                    <div class="bio">
-                      {{ gettext("Joey is the co-founder of Augur, the world’s first decentralized prediction market and oracle system. He is a Co-Chief Investment Officer at Pantera Capital.") }}
                     </div>
                   </div>
                 </div>
@@ -379,6 +311,91 @@
                     </div>
                     <div class="bio">
                       {{ gettext("Micah has been a commercial real estate broker for over a decade while developing software along the way. He is the technical cofounder of WellAttended, a bootstrapped box office management platform.") }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section class="advisor-team-section">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="container foreground-content">
+          <div class="row">
+            <div class="col-12">
+              <h2>
+                {{ gettext("Advisors") }}
+              </h2>
+              <div class="row">
+                <div class="col-12 col-md-6 col-xl-3">
+                  <div class="team-member">
+                    <div class="headshot-wrapper">
+                      <img src="/static/img/headshot-addison.jpg" class="headshot" alt="Addison Huegel headshot">
+                    </div>
+                    <div class="name">
+                      <a href="https://www.linkedin.com/in/addisonhuegel/" target="_blank">{{ gettext("Addison Huegel") }}
+                      </a>
+                    </div>
+                    <div class="title">
+                      {{ gettext("Advisor/PR") }}
+                    </div>
+                    <div class="bio">
+                      {{ gettext("Addison is a communications and marketing specialist with a degree in Physics from UC Berkeley. He previously worked with the Ethereum Foundation and DEVCON1.") }}
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                  <div class="team-member">
+                    <div class="headshot-wrapper">
+                      <img src="/static/img/headshot-melody.jpg" class="headshot" alt="Melody He headshot">
+                    </div>
+                    <div class="name">
+                      <a href="https://www.linkedin.com/in/melody-he-497a5b25/" target="_blank">{{ gettext("Melody He") }}
+                      </a>
+                    </div>
+                    <div class="title">
+                      {{ gettext("Advisor/International BD") }}
+                    </div>
+                    <div class="bio">
+                      {{ gettext("Melody is founder of Spartan Group, a blockchain advisory and investment fund. She was an early investor in TenX and strategic advisor to Gifto and Appcoins.") }}
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                  <div class="team-member">
+                    <div class="headshot-wrapper">
+                      <img src="/static/img/headshot-paul.jpg" class="headshot" alt="Paul Veradittakit headshot">
+                    </div>
+                    <div class="name">
+                      <a href="https://www.linkedin.com/in/veradittakit/" target="_blank">{{ gettext("Paul Veradittakit") }}
+                      </a>
+                    </div>
+                    <div class="title">
+                      {{ gettext("Advisor") }}
+                    </div>
+                    <div class="bio">
+                      {{ gettext("Paul is a Partner at Pantera Capital. He is also an advisor to several highly successful cryptocurrency projects including Orchid Labs, Enigma and ICON.") }}
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                  <div class="team-member">
+                    <div class="headshot-wrapper">
+                      <img src="/static/img/headshot-joey.jpg" class="headshot" alt="Joey Krug headshot">
+                    </div>
+                    <div class="name">
+                      <a href="https://www.linkedin.com/in/joeykrug/" target="_blank">{{ gettext("Joey Krug") }}
+                      </a>
+                    </div>
+                    <div class="title">
+                      {{ gettext("Advisor") }}
+                    </div>
+                    <div class="bio">
+                      {{ gettext("Joey is the co-founder of Augur, the world’s first decentralized prediction market and oracle system. He is a Co-Chief Investment Officer at Pantera Capital.") }}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Add an advisors section to team page, and move advisors into it. Rename "Contributing Team" to "Extended Team".

Closes #163

### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update the README, if neccessary