### PR TITLE
fixes l10n in roadmap whitepaper link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -418,7 +418,7 @@
                   <div class="when">
                     {{ gettext("September 2017") }}
                   </div>
-                  <a href="{{ url_for('product_brief', lang_code=CURRENT_LANGUAGE) }}">{{ gettext("Product Brief</a> and <a href='/whitepaper'>Whitepaper</a> released") }}
+                    {{ gettext("<a href='%(product_brief)s'>Product Brief</a> and <a href='%(whitepaper)s'>Whitepaper</a> released", whitepaper=url_for('whitepaper', lang_code=CURRENT_LANGUAGE) ,product_brief=url_for('product_brief', lang_code=CURRENT_LANGUAGE))}}
                 </div>
                 <div class="col-md-2 col-xs-12 blue-to-purple">
                   <div class="blue-circle"></div>


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double check you didn't break anything

### Description:

Please explain the changes you made here:

fixes #195 by passing urls for product_brief and whitepaper to gettext as variables.
This would need changes to translation files, 
example:
```
#: templates/index.html:399
#, python-format
msgid ""
"<a href='%(product_brief)s'>Product Brief</a> and <a "
"href='%(whitepaper)s'>Whitepaper</a> released"
msgstr ""
"<a href='%(product_brief)s'>Resumo do Produto</a> e <a "
"href='%(whitepaper)s'>Whitepaper</a> lançado"
```
@wanderingstan @micahalcorn let  me know what's the flow on doing the changes to translations. I thought of doing those changes in this branch itself, but the messages.pot template deviates quite a bit If I try to generate that on my local. Are we directly adding new strings to google toolkit and downloading archive and moving forward from there?
